### PR TITLE
deal with () in filenames by escaping them (NO_JIRA)

### DIFF
--- a/.github/workflows/quality_check.yml
+++ b/.github/workflows/quality_check.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/status_check.yml
+++ b/.github/workflows/status_check.yml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: "3.11"
       - name: Get the commit message
         run: |
           echo 'commit_message<<EOF' >> $GITHUB_ENV

--- a/main/githooks.py
+++ b/main/githooks.py
@@ -461,24 +461,24 @@ class TestTrimTrailingWhitespace(unittest.TestCase):
     def test_trim_trailing_whitespace(self):
         content = 'first line\nsecond line \nthird line '
         trimmed_content = 'first line\nsecond line\nthird line'
-        name = NamedTemporaryFile().name
-        Path(name).write_text(content)
-        # Trailing whitespace found
-        retval = trim_trailing_whitespace_in_file(name, True, True)
-        self.assertEqual(retval, 1)
-        self.assertEqual(Path(name).read_text(), content)
-
-        # Now remove the trailing whitespace
-        trim_trailing_whitespace_in_file(name, True, False, False)
-        # Trailing whitespace no longer found
-        self.assertEqual(Path(name).read_text(), trimmed_content)
-        retval = trim_trailing_whitespace_in_file(name, True, True)
-        self.assertEqual(retval, 0)
-
+        
         try:
+            name = NamedTemporaryFile().name
+            Path(name).write_text(content)
+            # Trailing whitespace found
+            retval = trim_trailing_whitespace_in_file(name, True, True)
+            self.assertEqual(retval, 1)
+            self.assertEqual(Path(name).read_text(), content)
+
+            # Now remove the trailing whitespace
+            trim_trailing_whitespace_in_file(name, True, False, False)
+            # Trailing whitespace no longer found
+            self.assertEqual(Path(name).read_text(), trimmed_content)
+            retval = trim_trailing_whitespace_in_file(name, True, True)
+            self.assertEqual(retval, 0)
+        finally:
             Path(name).unlink(name)
-        except Exception as e:
-            pass
+
 
     def test_decodeerror(self):
         # A text file that is not utf-8 encoded - report and skip

--- a/main/githooks.py
+++ b/main/githooks.py
@@ -133,7 +133,7 @@ def get_text_file_content(filename):
     if _is_github_event() or 'pytest' in sys.modules:
         data = Path(filename).read_text()
     else:
-        data = _get_output('git', 'show', f':{filename}')
+        data = _get_output(['git', 'show', f':{filename}'])
     return data
 
 

--- a/main/githooks.py
+++ b/main/githooks.py
@@ -56,13 +56,17 @@ CHECKED_EXTS = [
 # File types that need a terminating newline
 TERMINATING_NEWLINE_EXTS = ['.c', '.cpp', '.h', '.inl']
 
-esc_re = re.compile(r'\s|[]()[]')
+_esc_re = re.compile(r'\s|[]()[]')
 def _esc_char(match):
+    ''' Lambda function to add in back-slashes to escape special chars as compiled in esc_re above
+        which makes filenames work with subprocess commands
+    '''
     return '\\' + match.group(0)
 
-
 def _escape_filename(filename):
-    return esc_re.sub(_esc_char, filename)
+    ''' Return an escaped filename - for example fi(1)le.txt would be changed to fi\\(1\\)le.txt
+    '''
+    return _esc_re.sub(_esc_char, filename)
 
 
 def _get_output(command, cwd='.'):

--- a/main/githooks.py
+++ b/main/githooks.py
@@ -477,7 +477,7 @@ class TestTrimTrailingWhitespace(unittest.TestCase):
             retval = trim_trailing_whitespace_in_file(name, True, True)
             self.assertEqual(retval, 0)
         finally:
-            Path(name).unlink(name)
+            Path(name).unlink()
 
 
     def test_decodeerror(self):

--- a/main/githooks.py
+++ b/main/githooks.py
@@ -461,9 +461,9 @@ class TestTrimTrailingWhitespace(unittest.TestCase):
     def test_trim_trailing_whitespace(self):
         content = 'first line\nsecond line \nthird line '
         trimmed_content = 'first line\nsecond line\nthird line'
-        
+
+        name = NamedTemporaryFile().name        
         try:
-            name = NamedTemporaryFile().name
             Path(name).write_text(content)
             # Trailing whitespace found
             retval = trim_trailing_whitespace_in_file(name, True, True)

--- a/main/githooks.py
+++ b/main/githooks.py
@@ -146,7 +146,7 @@ def get_sha():
     GITHUB_SHA cannot be used because in a pull request it gives the sha of the
     fake merge commit.
     '''
-    return _get_output(['git','rev-parse', f'{get_branch()}'])
+    return _get_output(['git','rev-parse', get_branch()])
 
 
 def get_event():
@@ -159,13 +159,12 @@ def get_event():
 
 def get_branch_files():
     '''Get all files in branch'''
-    branch = get_branch()
-    return _get_output(['git','ls-tree', '-r', f'{branch}','--name-only']).splitlines()
+    return _get_output(['git','ls-tree', '-r', get_branch(),'--name-only']).splitlines()
 
 
 def add_file_to_index(filename):
     '''Add file to current commit'''
-    return _get_output(['git','add',f'{filename}'])
+    return _get_output(['git','add',filename])
 
 
 def get_commit_files():
@@ -284,7 +283,7 @@ class TestYieldChangedLines(unittest.TestCase):
 def get_config_setting(setting):
     '''Get the value of a config setting'''
     try:
-        return _get_output(['git', 'config', '--get', f'{setting}']).strip()
+        return _get_output(['git', 'config', '--get', setting]).strip()
     except subprocess.CalledProcessError:
         return None
 


### PR DESCRIPTION
This change should 'escape' file names when calling subprocess commands so that they dont fall down on linux platforms (as is currently happening in this PR) for filenames containing certain characters:

See: https://github.com/ccdc-confidential/cpp-apps-main/actions/runs/13816850366/job/38652179948?pr=4142

I'd appreciate a careful check - seems to work on my machine, but I've no easy way to test it in the 'live' repo.

Ironically the PR fails in checks ... because of the python version :-}

Update: PR now works since I've changed the python version in the PR. Horribly self-referential!

Update 2: following a chat with Simon & Matt - I've changed it so that we instead use subprocess without Shell=True - this should resolve the syntactic issues with files