### PR TITLE
create exception for .bat files in check_eol

### DIFF
--- a/main/githooks.py
+++ b/main/githooks.py
@@ -318,7 +318,8 @@ def check_eol(files):
         if '\0' in data:
             continue
 
-        if data.find('\r\n') != -1:
+        # Exception for .bat as they are only run in windows environments.
+        if data.find('\r\n') != -1 and not filename.endswith(".bat"):
             _fail(f'Bad line endings in {filename}')
             return 1
     return 0


### PR DESCRIPTION
- Create an exception for .bat files when checking EOL in a non auto crlf environment (linux)
- I think if core.autocrlf in the git config is true and the commit hook is run on a windows machine it will automatically perform the conversion of files specified in .gitattributes. However in the pipeline this is run in a linux machine and it checks all new and modified files for CRLF line endings and fails if it finds any (including .bat).