### PR TITLE
PLA-3204 conventional commit

### DIFF
--- a/main/githooks.py
+++ b/main/githooks.py
@@ -855,9 +855,12 @@ def check_commit_msg(message, files, repo):
         return 0
 
     
-    # Check for Conventional Commits compliance
-    if check_conventional_commit(message):
-        return 1
+    # Check for Conventional Commits compliance.
+    # Opt-in per repo: commit an empty marker file named
+    # `.conventional-commits` at the repo root.
+    if _conventional_commits_enabled():
+        if check_conventional_commit(message):
+            return 1
 
     if NO_JIRA_MARKER not in message:
         if jira_id_pattern.search(message) is None:
@@ -880,20 +883,35 @@ jira_id_pattern = re.compile(r'\b[A-Z]{2,8}-[0-9]{1,5}\b')
 
 
 
+def _conventional_commits_enabled():
+    '''Return True if the repo opts in to Conventional Commits enforcement.
+
+    Opt-in is signalled by a `.conventional-commits` file at the repo root.
+    '''
+    try:
+        repo_root = _get_output(['git', 'rev-parse', '--show-toplevel']).strip()
+    except subprocess.CalledProcessError:
+        return False
+    return (Path(repo_root) / '.conventional-commits').is_file()
+
+
 def check_conventional_commit(message):
-    '''Check if the commit message follows the Conventional Commits standard.'''
-    # Conventional Commits: type(scope?): subject\n\nbody\n\nfooter
-    # type: feat, fix, chore, docs, style, refactor, perf, test, build, ci, revert, etc.
+    '''Check if the commit message follows the Angular Conventional Commits standard.'''
+    # Angular Conventional Commits header: type(scope?)!?: subject
+    # Allowed types from @commitlint/config-angular:
+    #   build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test
     pattern = re.compile(
-        r'^(feat|fix|chore|docs|style|refactor|perf|test|build|ci|revert)'  # type
-        r'(\([\w\-]+\))?'  # optional scope
-        r'!?: '  # optional breaking change indicator and colon
+        r'^(BREAKING CHANGE|feat|fix|refactor|build|chore|ci|docs|perf|revert|style|test)'  # type
+        r'(\([\w\-\.\/]+\))?'  # optional scope
+        r'!?: '  # optional breaking change indicator and required ": "
         r'.+'  # subject
     )
     first_line = message.split('\n', 1)[0]
     if not pattern.match(first_line):
-        _fail('Commit message does not follow Conventional Commits standard.\n'
-              'See https://www.conventionalcommits.org/en/v1.0.0/')
+        _fail('Commit message does not follow the Angular Conventional '
+              'Commits standard.\n'
+              'Expected: <type>(<scope>)?!?: <subject>\n'
+              'See https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md')
         return 1
     return 0
 

--- a/main/githooks.py
+++ b/main/githooks.py
@@ -902,10 +902,7 @@ def _conventional_commits_enabled():
 
     Opt-in is signalled by a `.conventional-commits` file at the repo root.
     '''
-    try:
-        repo_root = _get_output(['git', 'rev-parse', '--show-toplevel']).strip()
-    except subprocess.CalledProcessError:
-        return False
+    repo_root = _get_output(['git', 'rev-parse', '--show-toplevel']).strip()
     return (Path(repo_root) / '.conventional-commits').is_file()
 
 

--- a/main/githooks.py
+++ b/main/githooks.py
@@ -897,20 +897,21 @@ def _conventional_commits_enabled():
 
 def check_conventional_commit(message):
     '''Check if the commit message follows the Angular Conventional Commits standard.'''
-    # Angular Conventional Commits header: type(scope?)!?: subject
+    # Angular Conventional Commits header: type(scope?): subject
     # Allowed types from @commitlint/config-angular:
     #   build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test
+    # Note: Angular does not use the `!` breaking-change marker in the header;
     pattern = re.compile(
         r'^(BREAKING CHANGE|feat|fix|refactor|build|chore|ci|docs|perf|revert|style|test)'  # type
         r'(\([\w\-\.\/]+\))?'  # optional scope
-        r'!?: '  # optional breaking change indicator and required ": "
+        r': '  # required ": "
         r'.+'  # subject
     )
     first_line = message.split('\n', 1)[0]
     if not pattern.match(first_line):
         _fail('Commit message does not follow the Angular Conventional '
               'Commits standard.\n'
-              'Expected: <type>(<scope>)?!?: <subject>\n'
+              'Expected: <type>(<scope>)?: <subject>\n'
               'See https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md')
         return 1
     return 0

--- a/main/githooks.py
+++ b/main/githooks.py
@@ -854,6 +854,11 @@ def check_commit_msg(message, files, repo):
         # Do not check for JIRA in opensource repo as we don't want to require external contributors to do this
         return 0
 
+    
+    # Check for Conventional Commits compliance
+    if check_conventional_commit(message):
+        return 1
+
     if NO_JIRA_MARKER not in message:
         if jira_id_pattern.search(message) is None:
             _fail('Every commit should contain a Jira issue ID or the text '
@@ -872,6 +877,25 @@ def check_commit_msg(message, files, repo):
 
     return 0
 jira_id_pattern = re.compile(r'\b[A-Z]{2,8}-[0-9]{1,5}\b')
+
+
+
+def check_conventional_commit(message):
+    '''Check if the commit message follows the Conventional Commits standard.'''
+    # Conventional Commits: type(scope?): subject\n\nbody\n\nfooter
+    # type: feat, fix, chore, docs, style, refactor, perf, test, build, ci, revert, etc.
+    pattern = re.compile(
+        r'^(feat|fix|chore|docs|style|refactor|perf|test|build|ci|revert)'  # type
+        r'(\([\w\-]+\))?'  # optional scope
+        r'!?: '  # optional breaking change indicator and colon
+        r'.+'  # subject
+    )
+    first_line = message.split('\n', 1)[0]
+    if not pattern.match(first_line):
+        _fail('Commit message does not follow Conventional Commits standard.\n'
+              'See https://www.conventionalcommits.org/en/v1.0.0/')
+        return 1
+    return 0
 
 
 class TestJiraIDPattern(unittest.TestCase):

--- a/main/githooks.py
+++ b/main/githooks.py
@@ -864,7 +864,11 @@ def check_commit_msg(message, files, repo):
     # Opt-in per repo: commit an empty marker file named
     # `.conventional-commits` at the repo root.
     if _conventional_commits_enabled():
-        if check_conventional_commit(message):
+        if not conventional_commit_present(message):
+            _fail('Commit message does not follow the Angular Conventional '
+                  'Commits standard.\n'
+                  'Expected: <type>(<scope>)?: <subject>\n'
+                  'See https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md')
             return 1
         
     if (
@@ -905,8 +909,8 @@ def _conventional_commits_enabled():
     return (Path(repo_root) / '.conventional-commits').is_file()
 
 
-def check_conventional_commit(message):
-    '''Check if the commit message follows the Angular Conventional Commits standard.'''
+def conventional_commit_present(message):
+    '''Return True if the commit message follows the Angular Conventional Commits standard.'''
     # Angular Conventional Commits header: type(scope?): subject
     # Allowed types from @commitlint/config-angular:
     #   build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test
@@ -918,13 +922,7 @@ def check_conventional_commit(message):
         r'.+'  # subject
     )
     first_line = message.split('\n', 1)[0]
-    if not pattern.match(first_line):
-        _fail('Commit message does not follow the Angular Conventional '
-              'Commits standard.\n'
-              'Expected: <type>(<scope>)?: <subject>\n'
-              'See https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md')
-        return 1
-    return 0
+    return pattern.match(first_line) is not None
 
 
 class TestJiraIDPattern(unittest.TestCase):

--- a/main/githooks.py
+++ b/main/githooks.py
@@ -867,7 +867,6 @@ def check_commit_msg(message, files, repo):
         if check_conventional_commit(message):
             return 1
         
-        
     if (
         NO_JIRA_MARKER not in message
         and copilot_autofix_coauthor_pattern.search(message) is None
@@ -877,14 +876,6 @@ def check_commit_msg(message, files, repo):
             'Every commit should contain a Jira issue ID, '
             f'{NO_JIRA_MARKER}, or be a Copilot Autofix commit'
         )
-    if (
-        NO_JIRA_MARKER not in message
-        and copilot_autofix_coauthor_pattern.search(message) is None
-        and jira_id_pattern.search(message) is None
-    ):
-        _fail(
-            'Every commit should contain a Jira issue ID, '
-            f'{NO_JIRA_MARKER}, or be a Copilot Autofix commit'
         return 1
 
     for filename in files:


### PR DESCRIPTION
Add support for checks on conventional commit standard when the repository is enabled, which is when a file called `.conventional-commits` is present at the repo root.